### PR TITLE
Auth: Add Login/Register Pages & Shared Form Components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@prisma/client": "^6.11.1",
+				"@radix-ui/react-label": "^2.1.7",
+				"@radix-ui/react-slot": "^1.2.3",
 				"@tanstack/react-query": "^5.82.0",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
@@ -1223,6 +1225,85 @@
 				"@prisma/debug": "6.11.1"
 			}
 		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-label": {
+			"version": "2.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+			"integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1645,7 +1726,7 @@
 			"version": "19.1.6",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
 			"integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
 	},
 	"dependencies": {
 		"@prisma/client": "^6.11.1",
+		"@radix-ui/react-label": "^2.1.7",
+		"@radix-ui/react-slot": "^1.2.3",
 		"@tanstack/react-query": "^5.82.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/src/app/(auth)/components/AuthFormWrapper.tsx
+++ b/src/app/(auth)/components/AuthFormWrapper.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface AuthFormWrapperProps {
+	children: ReactNode;
+	className?: string;
+}
+
+export default function AuthFormWrapper({ children, className }: AuthFormWrapperProps) {
+	return (
+		<main className={cn('flex min-h-screen items-center justify-center', className)}>
+			<div className='container flex min-w-lg flex-col items-center gap-10'>{children}</div>
+		</main>
+	);
+}

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,54 +1,54 @@
-import React from 'react';
+'use client';
 
-/**
- * Renders a centered login form UI with email and password input fields.
- *
- * Displays a styled card containing labeled input fields for email and password, along with a submit button. No form logic or state management is included.
- *
- * @returns The React element representing the login page UI.
- */
+import React, { FormEvent } from 'react';
+
+import NextLink from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { Button, FormInput } from '@/components';
+
+import AuthFormWrapper from '../components/AuthFormWrapper';
+
 export default function LoginPage() {
+	const router = useRouter();
+
+	const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+
+		router.push('/dashboard');
+	};
+
 	return (
-		<div className='flex min-h-screen items-center justify-center bg-gray-100'>
-			<div className='w-full max-w-md rounded-lg bg-white p-8 shadow-md'>
-				<h1 className='mb-6 text-center text-2xl font-bold'>Login</h1>
-				<form>
-					<div className='mb-4'>
-						<label
-							htmlFor='email'
-							className='block text-sm font-medium text-gray-700'
-						>
-							Email
-						</label>
-						<input
-							type='email'
-							id='email'
-							className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring focus:ring-indigo-200 focus:outline-none'
-							placeholder='Enter your email'
-						/>
-					</div>
-					<div className='mb-4'>
-						<label
-							htmlFor='password'
-							className='block text-sm font-medium text-gray-700'
-						>
-							Password
-						</label>
-						<input
-							type='password'
-							id='password'
-							className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring focus:ring-indigo-200 focus:outline-none'
-							placeholder='Enter your password'
-						/>
-					</div>
-					<button
+		<AuthFormWrapper>
+			<h1 className='h1'>Login to your account</h1>
+			<form
+				className='min-w-[25em]'
+				onSubmit={handleSubmit}
+			>
+				<div className='mb-10 flex flex-col gap-5'>
+					<FormInput
+						label='Email'
+						type='email'
+						name='email'
+						placeHolder='m@example.com'
+					/>
+					<FormInput
+						label='Password'
+						type='password'
+						name='password'
+						placeHolder='********'
+					/>
+				</div>
+				<div>
+					<Button
 						type='submit'
-						className='w-full rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 focus:ring focus:ring-indigo-300 focus:outline-none'
+						className='w-full'
 					>
 						Login
-					</button>
-				</form>
-			</div>
-		</div>
+					</Button>
+				</div>
+			</form>
+			<NextLink href='#'>Forgot your password?</NextLink>
+		</AuthFormWrapper>
 	);
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -48,7 +48,7 @@ export default function LoginPage() {
 					</Button>
 				</div>
 			</form>
-			<NextLink href='#'>Forgot your password?</NextLink>
+			<NextLink href='/forgot-password'>Forgot your password?</NextLink>
 		</AuthFormWrapper>
 	);
 }

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -1,68 +1,71 @@
-import React from 'react';
+'use client';
 
-/**
- * Renders a centered user registration form with fields for username, email, and password.
- *
- * The form is styled with a card-like appearance and includes labeled input fields and a submit button. No form submission logic or validation is implemented.
- *
- * @returns A React element displaying the registration form UI.
- */
+import React, { FormEvent } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { Button, FormInput } from '@/components';
+
+import AuthFormWrapper from '../components/AuthFormWrapper';
+
 export default function RegisterPage() {
+	const router = useRouter();
+
+	const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+		e.preventDefault();
+
+		router.push('/login');
+	};
+
 	return (
-		<div className='flex min-h-screen items-center justify-center bg-gray-100'>
-			<div className='w-full max-w-md rounded-lg bg-white p-8 shadow-md'>
-				<h1 className='mb-6 text-center text-2xl font-bold'>Register</h1>
-				<form>
-					<div className='mb-4'>
-						<label
-							htmlFor='username'
-							className='block text-sm font-medium text-gray-700'
-						>
-							Username
-						</label>
-						<input
-							type='text'
-							id='username'
-							className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring focus:ring-indigo-200 focus:outline-none'
-							placeholder='Enter your username'
-						/>
-					</div>
-					<div className='mb-4'>
-						<label
-							htmlFor='email'
-							className='block text-sm font-medium text-gray-700'
-						>
-							Email
-						</label>
-						<input
-							type='email'
-							id='email'
-							className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring focus:ring-indigo-200 focus:outline-none'
-							placeholder='Enter your email'
-						/>
-					</div>
-					<div className='mb-4'>
-						<label
-							htmlFor='password'
-							className='block text-sm font-medium text-gray-700'
-						>
-							Password
-						</label>
-						<input
-							type='password'
-							id='password'
-							className='mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:ring focus:ring-indigo-200 focus:outline-none'
-							placeholder='Enter your password'
-						/>
-					</div>
-					<button
-						type='submit'
-						className='w-full rounded-md bg-indigo-600 px-4 py-2 text-white hover:bg-indigo-700 focus:ring focus:ring-indigo-300 focus:outline-none'
-					>
-						Register
-					</button>
-				</form>
+		<AuthFormWrapper>
+			<div className='flex flex-col items-center'>
+				<h1 className='h1'>Create an account</h1>
+				<p className='body2'>Enter your credentials below to create your account</p>
 			</div>
-		</div>
+			<form
+				className='min-w-[25em]'
+				onSubmit={handleSubmit}
+			>
+				<div className='mb-10 flex flex-col gap-5'>
+					<FormInput
+						label='First name'
+						name='firstName'
+						placeHolder='Enter your first name'
+					/>
+					<FormInput
+						label='Last name'
+						name='lastName'
+						placeHolder='Enter your last name'
+					/>
+					<FormInput
+						label='Email'
+						type='email'
+						name='email'
+						placeHolder='m@example.com'
+					/>
+					<FormInput
+						label='Password'
+						type='password'
+						name='password'
+						placeHolder='Create a password'
+					/>
+					<FormInput
+						label='Confirm password'
+						type='password'
+						name='ConfirmPassword'
+						placeHolder='Confirm your password'
+					/>
+				</div>
+				<div>
+					<Button
+						type='submit'
+						className='w-full'
+					>
+						Create your account
+					</Button>
+				</div>
+			</form>
+		</AuthFormWrapper>
 	);
 }

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -14,7 +14,7 @@ export default function RegisterPage() {
 	const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
 		e.preventDefault();
 
-		router.push('/login');
+		router.push('/dashboard');
 	};
 
 	return (
@@ -53,7 +53,7 @@ export default function RegisterPage() {
 					<FormInput
 						label='Confirm password'
 						type='password'
-						name='ConfirmPassword'
+						name='confirmPassword'
 						placeHolder='Confirm your password'
 					/>
 				</div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -117,4 +117,20 @@
 	body {
 		@apply text-foreground bg-background;
 	}
+
+	/* Typography scale: heading + body text variants */
+	.h1{
+		@apply text-2xl font-semibold;
+	}
+	.body1{
+		@apply text-sm font-normal;
+	}
+	.body2{
+		@apply text-sm font-normal text-muted-foreground;
+	}
+
+	 /* Base link style */
+	a{
+		@apply text-sm underline underline-offset-4 hover:text-primary/80;
+	}
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,6 +122,9 @@
 	.h1{
 		@apply text-2xl font-semibold;
 	}
+	.h3{
+		@apply text-base font-semibold;
+	}
 	.body1{
 		@apply text-sm font-normal;
 	}

--- a/src/components/form/FormInput.tsx
+++ b/src/components/form/FormInput.tsx
@@ -1,0 +1,43 @@
+import { ChangeEvent, FocusEvent } from 'react';
+
+import { Input, Label } from '@/components';
+import { cn } from '@/lib/utils';
+
+interface FromInputProps {
+	label?: string;
+	type?: string;
+	name: string;
+	value?: string;
+	onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+	onBlur?: (event: FocusEvent<HTMLInputElement>) => void;
+	placeHolder?: string;
+	className?: string;
+}
+
+export default function FormInput({
+	label,
+	type = 'text',
+	name,
+	value,
+	onChange,
+	onBlur,
+	placeHolder,
+	className,
+	...props
+}: FromInputProps) {
+	return (
+		<div className='flex flex-col gap-2'>
+			{label && <Label>{label}</Label>}
+			<Input
+				{...props}
+				type={type}
+				name={name}
+				value={value}
+				onChange={onChange}
+				onBlur={onBlur}
+				placeholder={placeHolder}
+				className={cn(className)}
+			/>
+		</div>
+	);
+}

--- a/src/components/form/FormInput.tsx
+++ b/src/components/form/FormInput.tsx
@@ -3,9 +3,10 @@ import { ChangeEvent, FocusEvent } from 'react';
 import { Input, Label } from '@/components';
 import { cn } from '@/lib/utils';
 
-interface FromInputProps {
+interface FormInputProps {
 	label?: string;
 	type?: string;
+	id?: string;
 	name: string;
 	value?: string;
 	onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -17,6 +18,7 @@ interface FromInputProps {
 export default function FormInput({
 	label,
 	type = 'text',
+	id,
 	name,
 	value,
 	onChange,
@@ -24,12 +26,15 @@ export default function FormInput({
 	placeHolder,
 	className,
 	...props
-}: FromInputProps) {
+}: FormInputProps) {
+	const inputId = id || `input-${name}`;
+
 	return (
 		<div className='flex flex-col gap-2'>
-			{label && <Label>{label}</Label>}
+			{label && <Label htmlFor={inputId}>{label}</Label>}
 			<Input
 				{...props}
+				id={inputId}
 				type={type}
 				name={name}
 				value={value}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,5 @@
-// Placeholder for components barrel file
+export { default as FormInput } from './form/FormInput';
+
+export { Button } from './ui/button';
+export { Input } from './ui/input';
+export { Label } from './ui/label';

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,11 +6,11 @@ import { type VariantProps, cva } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-medium transition-all disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
 	{
 		variants: {
 			variant: {
-				default: 'bg-slate-700 text-primary-foreground shadow-xs hover:bg-slate-700/90',
+				default: 'bg-primary text-primary-foreground shadow-xs hover:bg-primary/90',
 				destructive:
 					'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
 				outline:
@@ -21,8 +21,8 @@ const buttonVariants = cva(
 			},
 			size: {
 				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
-				sm: 'h-8 rounded-sm gap-1.5 px-3 has-[>svg]:px-2.5',
-				lg: 'h-10 rounded-sm px-6 has-[>svg]:px-4',
+				sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
+				lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
 				icon: 'size-9',
 			},
 		},

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm text-sm font-medium transition-all disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
+	{
+		variants: {
+			variant: {
+				default: 'bg-slate-700 text-primary-foreground shadow-xs hover:bg-slate-700/90',
+				destructive:
+					'bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+				outline:
+					'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
+				secondary: 'bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80',
+				ghost: 'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+				link: 'text-primary underline-offset-4 hover:underline',
+			},
+			size: {
+				default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+				sm: 'h-8 rounded-sm gap-1.5 px-3 has-[>svg]:px-2.5',
+				lg: 'h-10 rounded-sm px-6 has-[>svg]:px-4',
+				icon: 'size-9',
+			},
+		},
+		defaultVariants: {
+			variant: 'default',
+			size: 'default',
+		},
+	},
+);
+
+function Button({
+	className,
+	variant,
+	size,
+	asChild = false,
+	...props
+}: React.ComponentProps<'button'> &
+	VariantProps<typeof buttonVariants> & {
+		asChild?: boolean;
+	}) {
+	const Comp = asChild ? Slot : 'button';
+
+	return (
+		<Comp
+			data-slot='button'
+			className={cn(buttonVariants({ variant, size, className }))}
+			{...props}
+		/>
+	);
+}
+
+export { Button, buttonVariants };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
 			type={type}
 			data-slot='input'
 			className={cn(
-				'file:text-foreground placeholder:text-muted-foreground/60 selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-sm border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+				'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 				'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[1px]',
 				'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
 				className,

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+	return (
+		<input
+			type={type}
+			data-slot='input'
+			className={cn(
+				'file:text-foreground placeholder:text-muted-foreground/60 selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-sm border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+				'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[1px]',
+				'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import * as React from 'react';
+
+import * as LabelPrimitive from '@radix-ui/react-label';
+
+import { cn } from '@/lib/utils';
+
+function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {
+	return (
+		<LabelPrimitive.Root
+			data-slot='label'
+			className={cn(
+				'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Label };


### PR DESCRIPTION
Closes: #4
---

### ✨ Summary
This PR scaffolds the authentication UI for the app: `Login` and `Register` pages wrapped in a shared `AuthFormWrapper` layout, and redirect behavior (Login → `/dashboard`; Register → `/login`). 


### ✅ Implemented

**🔐 Auth Pages**

- Created `/login` and `/register` page.
- Added redirect behavior.
- Provided `AuthFormWrapper` as a central layout used by both auth pages.

**🧾 Reusable Components**

- Added `FormInput` (label + input wrapper) for use in forms; supports common form props.
- Generated base `shadcn/ui` set in `components/ui/*` (Button, Input, Label) with minor style tweaks.
- Added barrel exports to `index.ts` for simpler imports.

**🎨 Global Styles (globals.css)**

- Added typography utility classes (`.h1`, `.body1`, `.body2`) for heading and body text.

**📸 UI Changes**

<img width="302" height="221" alt="LoginPage" src="https://github.com/user-attachments/assets/27d56c93-fcaf-4280-9cbb-29920b630ef4" />

<img width="302" height="357" alt="RegisterPage" src="https://github.com/user-attachments/assets/37deb2d3-575d-4206-8f15-3ad426174182" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced reusable components for form inputs, buttons, labels, and inputs to enhance consistency and modularity across forms.
  * Added layout wrappers for authentication forms, improving structure and alignment.
  * Expanded registration form with additional fields for first name, last name, and confirm password.
  * Enhanced login and registration pages with improved styling, client-side handling, and navigation.

* **Style**
  * Added global typography and link styles for a more cohesive visual appearance.

* **Refactor**
  * Updated login and registration pages to use new reusable components and structured layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->