### PR TITLE
Key Management: add page and modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
 			"version": "0.1.0",
 			"dependencies": {
 				"@prisma/client": "^6.11.1",
+				"@radix-ui/react-dialog": "^1.1.14",
+				"@radix-ui/react-select": "^2.2.5",
+				"@radix-ui/react-separator": "^1.1.7",
 				"@tanstack/react-query": "^5.82.0",
 				"class-variance-authority": "^0.7.1",
 				"clsx": "^2.1.1",
@@ -390,6 +393,44 @@
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
+		},
+		"node_modules/@floating-ui/core": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+			"integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/utils": "^0.2.10"
+			}
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+			"integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/core": "^1.7.2",
+				"@floating-ui/utils": "^0.2.10"
+			}
+		},
+		"node_modules/@floating-ui/react-dom": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.4.tgz",
+			"integrity": "sha512-JbbpPhp38UmXDDAu60RJmbeme37Jbgsm7NrHGgzYYFKmblzRUh6Pa641dII6LsjwF4XlScDrde2UAzDo/b9KPw==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/dom": "^1.7.2"
+			},
+			"peerDependencies": {
+				"react": ">=16.8.0",
+				"react-dom": ">=16.8.0"
+			}
+		},
+		"node_modules/@floating-ui/utils": {
+			"version": "0.2.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+			"integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+			"license": "MIT"
 		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
@@ -1223,6 +1264,585 @@
 				"@prisma/debug": "6.11.1"
 			}
 		},
+		"node_modules/@radix-ui/number": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+			"integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/primitive": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+			"integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+			"license": "MIT"
+		},
+		"node_modules/@radix-ui/react-arrow": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+			"integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-collection": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+			"integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+			"integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-context": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+			"integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dialog": {
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+			"integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.2",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-dismissable-layer": "1.1.10",
+				"@radix-ui/react-focus-guards": "1.1.2",
+				"@radix-ui/react-focus-scope": "1.1.7",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-presence": "1.1.4",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.6.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-direction": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+			"integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.1.10",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+			"integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/primitive": "1.1.2",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-escape-keydown": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
+			"integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+			"integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-id": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+			"integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-popper": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.7.tgz",
+			"integrity": "sha512-IUFAccz1JyKcf/RjB552PlWwxjeCJB8/4KxT7EhBHOJM+mN7LdW+B3kacJXILm32xawcMMjb2i0cIZpo+f9kiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@floating-ui/react-dom": "^2.0.0",
+				"@radix-ui/react-arrow": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-layout-effect": "1.1.1",
+				"@radix-ui/react-use-rect": "1.1.1",
+				"@radix-ui/react-use-size": "1.1.1",
+				"@radix-ui/rect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-portal": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+			"integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-presence": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+			"integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-primitive": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+			"integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-slot": "1.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-select": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.5.tgz",
+			"integrity": "sha512-HnMTdXEVuuyzx63ME0ut4+sEMYW6oouHWNGUZc7ddvUWIcfCva/AMoqEW/3wnEllriMWBa0RHspCYnfCWJQYmA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/number": "1.1.1",
+				"@radix-ui/primitive": "1.1.2",
+				"@radix-ui/react-collection": "1.1.7",
+				"@radix-ui/react-compose-refs": "1.1.2",
+				"@radix-ui/react-context": "1.1.2",
+				"@radix-ui/react-direction": "1.1.1",
+				"@radix-ui/react-dismissable-layer": "1.1.10",
+				"@radix-ui/react-focus-guards": "1.1.2",
+				"@radix-ui/react-focus-scope": "1.1.7",
+				"@radix-ui/react-id": "1.1.1",
+				"@radix-ui/react-popper": "1.2.7",
+				"@radix-ui/react-portal": "1.1.9",
+				"@radix-ui/react-primitive": "2.1.3",
+				"@radix-ui/react-slot": "1.2.3",
+				"@radix-ui/react-use-callback-ref": "1.1.1",
+				"@radix-ui/react-use-controllable-state": "1.2.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1",
+				"@radix-ui/react-use-previous": "1.1.1",
+				"@radix-ui/react-visually-hidden": "1.2.3",
+				"aria-hidden": "^1.2.4",
+				"react-remove-scroll": "^2.6.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-separator": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
+			"integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-slot": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+			"integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-compose-refs": "1.1.2"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+			"integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+			"integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-effect-event": "0.0.2",
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-effect-event": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+			"integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-escape-keydown": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+			"integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-callback-ref": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+			"integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-previous": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+			"integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-rect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+			"integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/rect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-use-size": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+			"integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-use-layout-effect": "1.1.1"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/react-visually-hidden": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+			"integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+			"license": "MIT",
+			"dependencies": {
+				"@radix-ui/react-primitive": "2.1.3"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"@types/react-dom": "*",
+				"react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@radix-ui/rect": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+			"integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+			"license": "MIT"
+		},
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1645,7 +2265,7 @@
 			"version": "19.1.6",
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
 			"integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"@types/react": "^19.0.0"
@@ -2298,6 +2918,18 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
+		},
+		"node_modules/aria-hidden": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+			"integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
@@ -2979,6 +3611,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/detect-node-es": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+			"integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+			"license": "MIT"
 		},
 		"node_modules/doctrine": {
 			"version": "2.1.0",
@@ -3883,6 +4521,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-nonce": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+			"integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/get-proto": {
@@ -6136,6 +6783,75 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/react-remove-scroll": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+			"integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+			"license": "MIT",
+			"dependencies": {
+				"react-remove-scroll-bar": "^2.3.7",
+				"react-style-singleton": "^2.2.3",
+				"tslib": "^2.1.0",
+				"use-callback-ref": "^1.3.3",
+				"use-sidecar": "^1.1.3"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-remove-scroll-bar": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+			"integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+			"license": "MIT",
+			"dependencies": {
+				"react-style-singleton": "^2.2.2",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/react-style-singleton": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+			"integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+			"license": "MIT",
+			"dependencies": {
+				"get-nonce": "^1.0.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/redis-errors": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
@@ -7218,6 +7934,49 @@
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/use-callback-ref": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+			"integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/use-sidecar": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+			"integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"detect-node-es": "^1.1.0",
+				"tslib": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"peerDependencies": {
+				"@types/react": "*",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
 	},
 	"dependencies": {
 		"@prisma/client": "^6.11.1",
+		"@radix-ui/react-dialog": "^1.1.14",
+		"@radix-ui/react-select": "^2.2.5",
+		"@radix-ui/react-separator": "^1.1.7",
 		"@tanstack/react-query": "^5.82.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",

--- a/src/app/(dashboard)/key-management/components/KeyCreateModal.tsx
+++ b/src/app/(dashboard)/key-management/components/KeyCreateModal.tsx
@@ -1,0 +1,86 @@
+import { Button, FormInput, Label, Select, Separator } from '@/components';
+import {
+	SelectContent,
+	SelectGroup,
+	SelectLabel,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { SheetFooter, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+
+export default function KeyCreateModal() {
+	return (
+		<>
+			<SheetHeader className='pb-0'>
+				<SheetTitle>Create virtual key</SheetTitle>
+			</SheetHeader>
+
+			<Separator />
+
+			<form className='flex h-full flex-col'>
+				<div className='grid flex-1 auto-rows-min gap-10 px-4'>
+					{/* Key Info */}
+					<div className='grid gap-5'>
+						<div>
+							<h3 className='h3'>Key details</h3>
+							<p className='body2'>
+								Assign an alias and description to help organise keys across projects and
+								environments.
+							</p>
+						</div>
+						<FormInput
+							label='Name of the key'
+							name='alias'
+							placeHolder='Alias'
+						/>
+						<FormInput
+							label='Description'
+							name='description'
+							placeHolder='A short description of the virtual key'
+						/>
+					</div>
+
+					{/* AI Provider Info */}
+					<div className='grid gap-5'>
+						<div>
+							<h3 className='h3'>AI provider settings</h3>
+							<p className='body2'>Add the credentials for your preferred AI provider.</p>
+						</div>
+						<div className='grid gap-2'>
+							<Label>AI provider</Label>
+							<Select>
+								<SelectTrigger className='w-full'>
+									<SelectValue placeholder='Select an AI provider' />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectGroup>
+										<SelectLabel>AI providers</SelectLabel>
+										{/* <SelectItem value=''></SelectItem> */}
+									</SelectGroup>
+								</SelectContent>
+							</Select>
+						</div>
+						<div className='grid gap-2'>
+							<Label>API key of the provider</Label>
+							<Select>
+								<SelectTrigger className='w-full'>
+									<SelectValue placeholder='Select an API key' />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectGroup>
+										<SelectLabel>API keys</SelectLabel>
+										{/* <SelectItem value=''></SelectItem> */}
+									</SelectGroup>
+								</SelectContent>
+							</Select>
+						</div>
+					</div>
+				</div>
+
+				<SheetFooter>
+					<Button type='submit'>Generate</Button>
+				</SheetFooter>
+			</form>
+		</>
+	);
+}

--- a/src/app/(dashboard)/key-management/components/KeyManagementContent.tsx
+++ b/src/app/(dashboard)/key-management/components/KeyManagementContent.tsx
@@ -1,0 +1,26 @@
+import { Button, SearchBar, Sheet } from '@/components';
+import { SheetContent, SheetTrigger } from '@/components/ui/sheet';
+
+import KeyCreateModal from './KeyCreateModal';
+import KeysTable from './KeysTable';
+
+export default function KeyManagementContent() {
+	return (
+		<Sheet>
+			<div className='mb-5 flex justify-between'>
+				<SearchBar />
+
+				<SheetTrigger asChild>
+					<Button>Create new virtual key</Button>
+				</SheetTrigger>
+			</div>
+			<div className='rounded-md border'>
+				<KeysTable />
+			</div>
+
+			<SheetContent>
+				<KeyCreateModal />
+			</SheetContent>
+		</Sheet>
+	);
+}

--- a/src/app/(dashboard)/key-management/components/KeysTable.tsx
+++ b/src/app/(dashboard)/key-management/components/KeysTable.tsx
@@ -1,0 +1,13 @@
+import { Table } from '@/components';
+
+import KeysTableBody from './KeysTableBody';
+import KeysTableHeader from './KeysTableHeader';
+
+export default function KeysTable() {
+	return (
+		<Table>
+			<KeysTableHeader />
+			<KeysTableBody />
+		</Table>
+	);
+}

--- a/src/app/(dashboard)/key-management/components/KeysTableBody.tsx
+++ b/src/app/(dashboard)/key-management/components/KeysTableBody.tsx
@@ -1,0 +1,17 @@
+import { EmptyState } from '@/components';
+import { TableBody, TableCell, TableRow } from '@/components/ui/table';
+
+export default function KeysTableBody() {
+	return (
+		<TableBody>
+			<TableRow>
+				<TableCell colSpan={5}>
+					<EmptyState
+						message='You haven’t created a key yet. Click on “Create key” to create your virtual key you can
+					share with your team.'
+					/>
+				</TableCell>
+			</TableRow>
+		</TableBody>
+	);
+}

--- a/src/app/(dashboard)/key-management/components/KeysTableHeader.tsx
+++ b/src/app/(dashboard)/key-management/components/KeysTableHeader.tsx
@@ -1,0 +1,15 @@
+import { TableHead, TableHeader, TableRow } from '@/components/ui/table';
+
+export default function KeysTableHeader() {
+	return (
+		<TableHeader>
+			<TableRow>
+				<TableHead className='w-[20%] pl-5'>NAME OF THE KEY</TableHead>
+				<TableHead className='w-[40%]'>KEY</TableHead>
+				<TableHead className='w-[20%]'>CREATED BY</TableHead>
+				<TableHead className='w-[15%]'>CREATED TIME</TableHead>
+				<TableHead className='w-[5%] pr-5 text-right'>ACTION</TableHead>
+			</TableRow>
+		</TableHeader>
+	);
+}

--- a/src/app/(dashboard)/key-management/page.tsx
+++ b/src/app/(dashboard)/key-management/page.tsx
@@ -1,0 +1,14 @@
+import { PageHeader } from '@/components';
+
+import KeyManagementContent from './components/KeyManagementContent';
+
+export default function KeyManagementPage() {
+	return (
+		<>
+			<PageHeader>Virtual key management</PageHeader>
+			<div className='px-20 py-10'>
+				<KeyManagementContent />
+			</div>
+		</>
+	);
+}

--- a/src/assets/icons/access/SearchIcon.tsx
+++ b/src/assets/icons/access/SearchIcon.tsx
@@ -1,0 +1,63 @@
+import React, { FC, SVGProps } from 'react';
+
+interface SearchIconProps extends SVGProps<SVGSVGElement> {
+	width?: number;
+	height?: number;
+	color?: string;
+	strokeWidth?: number;
+}
+
+/**
+ * A reusable SVG icon component for rendering an icon.
+ *
+ * @param {number} [width=24] - The width of the icon in pixels. Optional.
+ * @param {number} [height=24] - The height of the icon in pixels. Optional.
+ * @param {string} [color='#71717A'] - The stroke color of the icon. Accepts any valid CSS color value. Optional.
+ * @param {number} [strokeWidth=2] - The stroke width of the icon's path. Optional.
+ * @param {SVGProps<SVGSVGElement>} props - Additional SVG props such as `className`, `style`, or custom attributes.
+ *
+ * @returns {JSX.Element} A scalable vector graphic (SVG) element representing the icon.
+ */
+
+const SearchIcon: FC<SearchIconProps> = ({
+	width = 24,
+	height = 24,
+	color = '#71717A',
+	strokeWidth = 2,
+	...props
+}) => {
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox='0 0 24 24'
+			fill='none'
+			xmlns='http://www.w3.org/2000/svg'
+			role='img'
+			aria-label='Search Icon'
+			{...props}
+		>
+			<circle
+				cx='11'
+				cy='11'
+				r='7'
+				stroke={color}
+				strokeWidth={strokeWidth}
+				strokeLinecap='round'
+				strokeLinejoin='round'
+			/>
+			<line
+				x1='16.65'
+				y1='16.65'
+				x2='21'
+				y2='21'
+				stroke={color}
+				strokeWidth={strokeWidth}
+				strokeLinecap='round'
+				strokeLinejoin='round'
+			/>
+		</svg>
+	);
+};
+
+export default SearchIcon;

--- a/src/assets/icons/general/EmptyStateIcon.tsx
+++ b/src/assets/icons/general/EmptyStateIcon.tsx
@@ -1,0 +1,192 @@
+import React, { FC, SVGProps } from 'react';
+
+interface EmptyStateIconProps extends SVGProps<SVGSVGElement> {
+	width?: number;
+	height?: number;
+}
+
+/**
+ * A reusable SVG icon component for rendering an icon.
+ *
+ * @param {number} [width=140] - The width of the icon in pixels. Optional.
+ * @param {number} [height=110] - The height of the icon in pixels. Optional.
+ * @param {SVGProps<SVGSVGElement>} props - Additional SVG props such as `className`, `style`, or custom attributes.
+ *
+ * @returns {JSX.Element} A scalable vector graphic (SVG) element representing the icon.
+ */
+
+const EmptyStateIcon: FC<EmptyStateIconProps> = ({ width = 140, height = 110, ...props }) => {
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox='12 7 150 120'
+			fill='none'
+			xmlns='http://www.w3.org/2000/svg'
+			aria-label='Empty State Icon'
+			role='img'
+			{...props}
+		>
+			<rect
+				width='138'
+				height='107'
+				fill='#F5F5F5'
+			/>
+			<g clipPath='url(#clip0_0_1)'>
+				<rect
+					width='1440'
+					height='1054'
+					transform='translate(-711 -175)'
+					fill='#FCFCFD'
+				/>
+				<rect
+					x='-415.5'
+					y='-41.5'
+					width='1096'
+					height='262'
+					fill='white'
+				/>
+				<rect
+					x='-415.5'
+					y='-41.5'
+					width='1096'
+					height='262'
+					stroke='#ECECEC'
+				/>
+				<g clipPath='url(#bgblur_1_0_1_clip_path)'>
+					<foreignObject
+						x='0.553192'
+						y='0.0425539'
+						width='138'
+						height='107'
+					>
+						<div style={{ backdropFilter: 'blur(1.74px)', height: '100%', width: '100%' }}></div>
+					</foreignObject>
+				</g>
+				<g filter='url(#filter0_d_0_1)'>
+					<rect
+						x='18'
+						y='14'
+						width='138'
+						height='107'
+						rx='4'
+						fill='white'
+						fillOpacity='0.5'
+						shapeRendering='crispEdges'
+					/>
+					<rect
+						x='18.4362'
+						y='14.4362'
+						width='137.128'
+						height='106.128'
+						rx='3.56383'
+						stroke='#F2F2F2'
+						strokeWidth='0.87234'
+						shapeRendering='crispEdges'
+					/>
+				</g>
+				<rect
+					x='38'
+					y='73'
+					width='73'
+					height='10'
+					rx='4'
+					fill='#E4E5E9'
+					fillOpacity='0.5'
+				/>
+				<rect
+					x='38'
+					y='89'
+					width='62'
+					height='10'
+					rx='4'
+					fill='#E4E5E9'
+					fillOpacity='0.5'
+				/>
+				<path
+					d='M120 49C120 49 121.5 51 124 51C126.5 51 128 49 128 49M129 44.24C128.605 44.725 128.065 45 127.5 45C126.935 45 126.41 44.725 126 44.24M122 44.24C121.605 44.725 121.065 45 120.5 45C119.935 45 119.41 44.725 119 44.24M134 47C134 52.5228 129.523 57 124 57C118.477 57 114 52.5228 114 47C114 41.4772 118.477 37 124 37C129.523 37 134 41.4772 134 47Z'
+					stroke='#A3A3A3'
+					strokeWidth='2'
+					strokeLinecap='round'
+					strokeLinejoin='round'
+				/>
+				<path
+					d='M46 49C46 49 47.5 51 50 51C52.5 51 54 49 54 49M53 44H53.01M47 44H47.01M60 47C60 52.5228 55.5228 57 50 57C44.4772 57 40 52.5228 40 47C40 41.4772 44.4772 37 50 37C55.5228 37 60 41.4772 60 47ZM53.5 44C53.5 44.2761 53.2761 44.5 53 44.5C52.7239 44.5 52.5 44.2761 52.5 44C52.5 43.7239 52.7239 43.5 53 43.5C53.2761 43.5 53.5 43.7239 53.5 44ZM47.5 44C47.5 44.2761 47.2761 44.5 47 44.5C46.7239 44.5 46.5 44.2761 46.5 44C46.5 43.7239 46.7239 43.5 47 43.5C47.2761 43.5 47.5 43.7239 47.5 44Z'
+					stroke='#A3A3A3'
+					strokeWidth='2'
+					strokeLinecap='round'
+					strokeLinejoin='round'
+				/>
+				<path
+					d='M83 49C83 49 84.5 51 87 51C89.5 51 91 49 91 49M90 44H90.01M83 44H85M97 47C97 52.5228 92.5228 57 87 57C81.4772 57 77 52.5228 77 47C77 41.4772 81.4772 37 87 37C92.5228 37 97 41.4772 97 47ZM90.5 44C90.5 44.2761 90.2761 44.5 90 44.5C89.7239 44.5 89.5 44.2761 89.5 44C89.5 43.7239 89.7239 43.5 90 43.5C90.2761 43.5 90.5 43.7239 90.5 44Z'
+					stroke='#A3A3A3'
+					strokeWidth='2'
+					strokeLinecap='round'
+					strokeLinejoin='round'
+				/>
+			</g>
+			<defs>
+				<filter
+					id='filter0_d_0_1'
+					x='0.553192'
+					y='0.0425539'
+					width='172.894'
+					height='141.894'
+					filterUnits='userSpaceOnUse'
+					colorInterpolationFilters='sRGB'
+				>
+					<feFlood
+						floodOpacity='0'
+						result='BackgroundImageFix'
+					/>
+					<feColorMatrix
+						in='SourceAlpha'
+						type='matrix'
+						values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0'
+						result='hardAlpha'
+					/>
+					<feOffset dy='3.48936' />
+					<feGaussianBlur stdDeviation='8.7234' />
+					<feComposite
+						in2='hardAlpha'
+						operator='out'
+					/>
+					<feColorMatrix
+						type='matrix'
+						values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.04 0'
+					/>
+					<feBlend
+						mode='normal'
+						in2='BackgroundImageFix'
+						result='effect1_dropShadow_0_1'
+					/>
+					<feBlend
+						mode='normal'
+						in='SourceGraphic'
+						in2='effect1_dropShadow_0_1'
+						result='shape'
+					/>
+				</filter>
+				<clipPath id='bgblur_1_0_1_clip_path'>
+					<rect
+						x='18'
+						y='14'
+						width='138'
+						height='107'
+						rx='4'
+					/>
+				</clipPath>
+				<clipPath id='clip0_0_1'>
+					<rect
+						width='1440'
+						height='1054'
+						fill='white'
+						transform='translate(-711 -175)'
+					/>
+				</clipPath>
+			</defs>
+		</svg>
+	);
+};
+
+export default EmptyStateIcon;

--- a/src/assets/icons/index.ts
+++ b/src/assets/icons/index.ts
@@ -1,0 +1,3 @@
+export { default as SearchIcon } from './access/SearchIcon';
+
+export { default as EmptyStateIcon } from './general/EmptyStateIcon';

--- a/src/components/common/EmptyState.tsx
+++ b/src/components/common/EmptyState.tsx
@@ -1,0 +1,60 @@
+import { ReactNode } from 'react';
+
+import { EmptyStateIcon } from '@/assets/icons';
+import { Button } from '@/components';
+import { cn } from '@/lib/utils';
+
+interface EmptyStateProps {
+	message: string;
+	icon?: ReactNode;
+	buttonText?: string;
+	buttonAction?: () => void;
+	children?: ReactNode;
+	className?: string;
+}
+
+/**
+ * A reusable empty state component for empty items, such as tables, that are completely out of data.
+ * For example, in the parent component, we can handle the following code:
+ * {!data.length && <EmptyState message="No contacts found." icon={<EmptyStateIcon />}}
+ *
+ * @param {string} [message] - The message of empty states. Required.
+ * @param {ReactNode} [icon = <EmptyStateIcon />] - The icon of empty states. Optional.
+ * @param {string} [buttonText] - The button text of empty states. Optional.
+ * @param {() => void} [buttonAction] - The button action of empty states. Optional.
+ * @param {ReactNode} [children] - Custom JSX elements for more complex empty states (e.g., multiple buttons or additional text). Optional.
+ * @param {string} [className] - Additional Tailwind/CSS classes for the root wrapper. Optional.
+ *
+ * @returns {JSX.Element} A scalable and responsive design including a message, icon, button, or passed children.
+ */
+
+export default function EmptyState({
+	message,
+	icon = <EmptyStateIcon />,
+	buttonText,
+	buttonAction,
+	children,
+	className,
+	...props
+}: EmptyStateProps) {
+	return (
+		<div
+			className={cn('container flex flex-col items-center py-10 md:py-12 lg:py-16', className)}
+			{...props}
+		>
+			{icon && <div className='mb-1 box-border md:mb-2 lg:mb-4'>{icon}</div>}
+
+			<div>
+				<p>{message}</p>
+			</div>
+
+			{buttonText && buttonAction ? (
+				<div className='mt-12 md:mt-14 lg:mt-16'>
+					<Button onClick={buttonAction}>{buttonText}</Button>
+				</div>
+			) : (
+				children && <div className='mt-12 md:mt-14 lg:mt-16'>{children}</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/common/PageHeader.tsx
+++ b/src/components/common/PageHeader.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+
+import { Separator } from '@/components';
+import { cn } from '@/lib/utils';
+
+interface PageHeaderProps {
+	children: ReactNode;
+	className?: string;
+}
+
+export default function PageHeader({ children, className, ...props }: PageHeaderProps) {
+	return (
+		<div
+			className={cn(className)}
+			{...props}
+		>
+			<div className='p-5 pl-20'>
+				<header className='h3'>{children}</header>
+			</div>
+			<Separator />
+		</div>
+	);
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,9 @@
-// Placeholder for components barrel file
+export { default as SearchBar } from './input/SearchBar';
+
+export { default as EmptyState } from './common/EmptyState';
+export { default as PageHeader } from './common/PageHeader';
+
+export { Separator } from './ui/separator';
+export { Table } from './ui/table';
+export { Select } from './ui/select';
+export { Sheet } from './ui/sheet';

--- a/src/components/input/SearchBar.tsx
+++ b/src/components/input/SearchBar.tsx
@@ -1,0 +1,23 @@
+import { SearchIcon } from '@/assets/icons';
+import { Input } from '@/components';
+import { cn } from '@/lib/utils';
+
+interface SearchBarProps {
+	className?: string;
+}
+
+export default function SearchBar({ className, ...props }: SearchBarProps) {
+	return (
+		<div
+			className={cn('relative w-80', className)}
+			{...props}
+		>
+			<SearchIcon className='absolute top-0 bottom-0 left-3 my-auto' />
+			<Input
+				type='text'
+				placeholder='Search'
+				className='pr-4 pl-12'
+			/>
+		</div>
+	);
+}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import * as React from 'react';
+
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function Select({ ...props }: React.ComponentProps<typeof SelectPrimitive.Root>) {
+	return (
+		<SelectPrimitive.Root
+			data-slot='select'
+			{...props}
+		/>
+	);
+}
+
+function SelectGroup({ ...props }: React.ComponentProps<typeof SelectPrimitive.Group>) {
+	return (
+		<SelectPrimitive.Group
+			data-slot='select-group'
+			{...props}
+		/>
+	);
+}
+
+function SelectValue({ ...props }: React.ComponentProps<typeof SelectPrimitive.Value>) {
+	return (
+		<SelectPrimitive.Value
+			data-slot='select-value'
+			{...props}
+		/>
+	);
+}
+
+function SelectTrigger({
+	className,
+	size = 'default',
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+	size?: 'sm' | 'default';
+}) {
+	return (
+		<SelectPrimitive.Trigger
+			data-slot='select-trigger'
+			data-size={size}
+			className={cn(
+				"border-input data-[placeholder]:text-muted-foreground [&_svg:not([class*='text-'])]:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 dark:hover:bg-input/50 flex w-fit items-center justify-between gap-2 rounded-md border bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<SelectPrimitive.Icon asChild>
+				<ChevronDownIcon className='size-4 opacity-50' />
+			</SelectPrimitive.Icon>
+		</SelectPrimitive.Trigger>
+	);
+}
+
+function SelectContent({
+	className,
+	children,
+	position = 'popper',
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+	return (
+		<SelectPrimitive.Portal>
+			<SelectPrimitive.Content
+				data-slot='select-content'
+				className={cn(
+					'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border shadow-md',
+					position === 'popper' &&
+						'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+					className,
+				)}
+				position={position}
+				{...props}
+			>
+				<SelectScrollUpButton />
+				<SelectPrimitive.Viewport
+					className={cn(
+						'p-1',
+						position === 'popper' &&
+							'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1',
+					)}
+				>
+					{children}
+				</SelectPrimitive.Viewport>
+				<SelectScrollDownButton />
+			</SelectPrimitive.Content>
+		</SelectPrimitive.Portal>
+	);
+}
+
+function SelectLabel({ className, ...props }: React.ComponentProps<typeof SelectPrimitive.Label>) {
+	return (
+		<SelectPrimitive.Label
+			data-slot='select-label'
+			className={cn('text-muted-foreground px-2 py-1.5 text-xs', className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectItem({
+	className,
+	children,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+	return (
+		<SelectPrimitive.Item
+			data-slot='select-item'
+			className={cn(
+				"focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+				className,
+			)}
+			{...props}
+		>
+			<span className='absolute right-2 flex size-3.5 items-center justify-center'>
+				<SelectPrimitive.ItemIndicator>
+					<CheckIcon className='size-4' />
+				</SelectPrimitive.ItemIndicator>
+			</span>
+			<SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+		</SelectPrimitive.Item>
+	);
+}
+
+function SelectSeparator({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+	return (
+		<SelectPrimitive.Separator
+			data-slot='select-separator'
+			className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+			{...props}
+		/>
+	);
+}
+
+function SelectScrollUpButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+	return (
+		<SelectPrimitive.ScrollUpButton
+			data-slot='select-scroll-up-button'
+			className={cn('flex cursor-default items-center justify-center py-1', className)}
+			{...props}
+		>
+			<ChevronUpIcon className='size-4' />
+		</SelectPrimitive.ScrollUpButton>
+	);
+}
+
+function SelectScrollDownButton({
+	className,
+	...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+	return (
+		<SelectPrimitive.ScrollDownButton
+			data-slot='select-scroll-down-button'
+			className={cn('flex cursor-default items-center justify-center py-1', className)}
+			{...props}
+		>
+			<ChevronDownIcon className='size-4' />
+		</SelectPrimitive.ScrollDownButton>
+	);
+}
+
+export {
+	Select,
+	SelectContent,
+	SelectGroup,
+	SelectItem,
+	SelectLabel,
+	SelectScrollDownButton,
+	SelectScrollUpButton,
+	SelectSeparator,
+	SelectTrigger,
+	SelectValue,
+};

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as React from 'react';
+
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+
+import { cn } from '@/lib/utils';
+
+function Separator({
+	className,
+	orientation = 'horizontal',
+	decorative = true,
+	...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+	return (
+		<SeparatorPrimitive.Root
+			data-slot='separator'
+			decorative={decorative}
+			orientation={orientation}
+			className={cn(
+				'bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+export { Separator };

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import * as React from 'react';
+
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+	return (
+		<SheetPrimitive.Root
+			data-slot='sheet'
+			{...props}
+		/>
+	);
+}
+
+function SheetTrigger({ ...props }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+	return (
+		<SheetPrimitive.Trigger
+			data-slot='sheet-trigger'
+			{...props}
+		/>
+	);
+}
+
+function SheetClose({ ...props }: React.ComponentProps<typeof SheetPrimitive.Close>) {
+	return (
+		<SheetPrimitive.Close
+			data-slot='sheet-close'
+			{...props}
+		/>
+	);
+}
+
+function SheetPortal({ ...props }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+	return (
+		<SheetPrimitive.Portal
+			data-slot='sheet-portal'
+			{...props}
+		/>
+	);
+}
+
+function SheetOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+	return (
+		<SheetPrimitive.Overlay
+			data-slot='sheet-overlay'
+			className={cn(
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function SheetContent({
+	className,
+	children,
+	side = 'right',
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+	side?: 'top' | 'right' | 'bottom' | 'left';
+}) {
+	return (
+		<SheetPortal>
+			<SheetOverlay />
+			<SheetPrimitive.Content
+				data-slot='sheet-content'
+				className={cn(
+					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+					side === 'right' &&
+						'data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm',
+					side === 'left' &&
+						'data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm',
+					side === 'top' &&
+						'data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b',
+					side === 'bottom' &&
+						'data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t',
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				<SheetPrimitive.Close className='ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none'>
+					<XIcon className='size-4' />
+					<span className='sr-only'>Close</span>
+				</SheetPrimitive.Close>
+			</SheetPrimitive.Content>
+		</SheetPortal>
+	);
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot='sheet-header'
+			className={cn('flex flex-col gap-1.5 p-4', className)}
+			{...props}
+		/>
+	);
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot='sheet-footer'
+			className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+			{...props}
+		/>
+	);
+}
+
+function SheetTitle({ className, ...props }: React.ComponentProps<typeof SheetPrimitive.Title>) {
+	return (
+		<SheetPrimitive.Title
+			data-slot='sheet-title'
+			className={cn('text-foreground font-semibold', className)}
+			{...props}
+		/>
+	);
+}
+
+function SheetDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+	return (
+		<SheetPrimitive.Description
+			data-slot='sheet-description'
+			className={cn('text-muted-foreground text-sm', className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Sheet,
+	SheetTrigger,
+	SheetClose,
+	SheetContent,
+	SheetHeader,
+	SheetFooter,
+	SheetTitle,
+	SheetDescription,
+};

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Table({ className, ...props }: React.ComponentProps<'table'>) {
+	return (
+		<div
+			data-slot='table-container'
+			className='relative w-full overflow-x-auto'
+		>
+			<table
+				data-slot='table'
+				className={cn('w-full caption-bottom text-sm', className)}
+				{...props}
+			/>
+		</div>
+	);
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<'thead'>) {
+	return (
+		<thead
+			data-slot='table-header'
+			className={cn('[&_tr]:border-b', className)}
+			{...props}
+		/>
+	);
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<'tbody'>) {
+	return (
+		<tbody
+			data-slot='table-body'
+			className={cn('[&_tr:last-child]:border-0', className)}
+			{...props}
+		/>
+	);
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<'tfoot'>) {
+	return (
+		<tfoot
+			data-slot='table-footer'
+			className={cn('bg-muted/50 border-t font-medium [&>tr]:last:border-b-0', className)}
+			{...props}
+		/>
+	);
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<'tr'>) {
+	return (
+		<tr
+			data-slot='table-row'
+			className={cn(
+				'hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<'th'>) {
+	return (
+		<th
+			data-slot='table-head'
+			className={cn(
+				'text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<'td'>) {
+	return (
+		<td
+			data-slot='table-cell'
+			className={cn(
+				'p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) {
+	return (
+		<caption
+			data-slot='table-caption'
+			className={cn('text-muted-foreground mt-4 text-sm', className)}
+			{...props}
+		/>
+	);
+}
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };


### PR DESCRIPTION
Closes: #6
---

### ✨ Summary  

This PR delivers the initial **Key Management** feature set.  
It adds a Key Management page under `app/(dashboard)/key-management` with a table, a `KeyCreate` modal, new SVG icons, and several reusable components. 
<br>
### ✅ Implemented  

**🗝️ Key Management**  

- Added `key-management` page.
- Built feature-specific components:  

  - `KeyManagementContent` (page shell)  
  - `KeysTable`, `KeysTableHeader`, `KeysTableBody`
  - `KeyCreateModal` (shadcn `<Sheet>`-based modal)  

- Hooked up the `Create Key` button to open the modal on the key-management page
<br>

**🎨 Icons**  

- Created `SearchIcon` and `EmptyStateIcon` icons and converted them to React components.  
- Added `src/assets/icons/index.ts` barrel for cleaner imports.
<br>

**🧩 Reusable Components**  

- Added reusable UI primitives for use throughout the app:  

  - `SearchBar`  
  - `PageHeader`  
  - `EmptyState`
<br>

**🛠️ shadcn/ui Base Set**  

- Installed and generated base primitives: `Select`, `Separator`, `Sheet`, and `Table`. 
<br>

**📸 UI Changes**

<img width="719" height="368" alt="KeyM1" src="https://github.com/user-attachments/assets/9fa3a953-fba0-49eb-a97a-e88cca4902fa" />

<img width="289" height="440" alt="KeyM2" src="https://github.com/user-attachments/assets/1e5d2576-5956-45d0-9a28-edbbd954a3fa" />
