### PR TITLE
docs: update Node.js requirements and security reporting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -31,7 +31,13 @@ Community leaders have the right and responsibility to remove, edit, or reject c
 This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [conduct@yourdomain.example](mailto:conduct@yourdomain.example) **(TODO: replace with a monitored alias)** or via the GitHub "Contact maintainers" link where available. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported in the following ways:
+
+- **Sensitive incidents:** Open a private report via GitHub Security Advisories: https://github.com/bluewave-labs/LangRoute/security/advisories/new
+- **Other Code of Conduct concerns:** Open a GitHub issue labeled "code of conduct".
+- **TODO:** Add a project email alias for reports once available.
+
+All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident and will not publicly name individuals without consent.
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See the [architecture document](docs/architecture.md) for a deeper dive into sys
 
 ## Quick start
 ### Prerequisites
-- Node.js 20+ (recommended)
+- Node.js 20+
 - npm (bundled with Node)
 
 ### Environment

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ This document explains how to report vulnerabilities in LangRoute and what to ex
 ## Reporting a Vulnerability
 Please report security issues privately.
 
-- **GitHub Security Advisories:** Use the repository's **Security** tab and click **Report a vulnerability**.
-- **Email:** If GitHub advisories are unavailable, contact [security@yourdomain.example](mailto:security@yourdomain.example) **(TODO: replace with a monitored alias)**.
+- **GitHub Security Advisories:** Use the repository's Security tab and click **Report a vulnerability**: https://github.com/bluewave-labs/LangRoute/security/advisories/new
+- TODO: Add a project security email for reports once available.
 
 Please do not open public issues for security problems.
 
@@ -57,6 +57,6 @@ Out of scope:
 | TODO    | TODO (maintainers to define supported versions) |
 
 ## Contact / Encryption
-If you need to encrypt your report, please reach out via email to request our PGP key (TODO: provide key).
+If you need to encrypt your report, TODO: provide a project email and PGP key when available.
 
 Thank you for helping keep LangRoute and its users safe.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,7 +94,7 @@ npm run start
 - **Port 5432 already in use** – stop local services using the port or change the mapping in `docker/docker-compose.db.yml`.
 - **Prisma migrate errors** – confirm the DB is running and the root `.env` exists, then re-run `npx prisma generate` and `npx prisma migrate dev`.
 - **Environment changes not applied** – re-run `npm run env` or restart with `npm run dev` to regenerate `.env`.
-- **Node version mismatch** – use Node.js 18.18 (minimum) or newer.
+- **Node version mismatch** – use Node.js 20+.
 - **Stale database data** – `npm run db reset` recreates containers; `npm run db nuke` wipes volumes.
 
 ## Platform notes

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "lang-route",
 	"version": "0.1.0",
 	"private": true,
+	"engines": {
+		"node": ">=20"
+	},
 	"scripts": {
 		"dev": "node scripts/dev.mjs",
 		"build": "next build",

--- a/src/app/(client)/page.tsx
+++ b/src/app/(client)/page.tsx
@@ -124,27 +124,19 @@ export default function HomePage() {
 
 					<div className='text-muted-foreground mt-4 flex items-center space-x-6 text-sm sm:mt-0'>
 						<a
-							href='https://github.com/bluewave-labs/langRoute'
+							href='https://github.com/bluewave-labs/LangRoute'
 							target='_blank'
 							rel='noopener noreferrer'
 							className='hover:text-foreground'
 						>
 							GitHub
 						</a>
-						<a
-							href='https://docs.langRoute.dev'
-							target='_blank'
-							rel='noopener noreferrer'
-							className='hover:text-foreground'
-						>
-							Documentation
-						</a>
-						<a
-							href='mailto:support@langRoute.dev'
-							className='hover:text-foreground'
-						>
-							Support
-						</a>
+						<span className='text-muted-foreground'>
+							[TODO: Insert external docs site link when available]
+						</span>
+						<span className='text-muted-foreground'>
+							[TODO: Insert support contact when available]
+						</span>
 					</div>
 				</div>
 			</footer>


### PR DESCRIPTION
## Summary
- fix GitHub link casing and drop placeholder docs/support links
- require Node.js 20+ and note engines field
- route security and conduct reports through GitHub Security Advisories

## Testing
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a405356cd4832d9ec12f157e1157f2