### PR TITLE
Integrate end-to-end forgot/reset password and logout flows (RHF + Zod, TanStack Query)

### DIFF
--- a/public/assets/icons/general/CheckCircleIcon.tsx
+++ b/public/assets/icons/general/CheckCircleIcon.tsx
@@ -1,0 +1,78 @@
+import React, { FC, SVGProps } from 'react';
+
+type IconColor = 'error' | 'success' | 'disabled' | 'outline' | 'primaryOutline';
+
+const colorMap: Record<IconColor, string> = {
+	error: '#F04438',
+	success: '#067647',
+	disabled: '#D0D5DD',
+	outline: '#344054',
+	primaryOutline: '#1570ef',
+};
+
+interface CheckCircleIconProps extends SVGProps<SVGSVGElement> {
+	width?: number;
+	height?: number;
+	color?: IconColor;
+}
+
+/**
+ * A reusable SVG icon component for rendering an icon.
+ *
+ * @param {number} [width=24] - The width of the icon in pixels. Optional.
+ * @param {number} [height=24] - The height of the icon in pixels. Optional.
+ * @param {IconColor} [color='disabled'] - The stroke color of the icon. Accepts any valid CSS color value. Optional.
+ * @param {SVGProps<SVGSVGElement>} props - Additional SVG props such as `className`, `style`, or custom attributes.
+ *
+ * @returns {JSX.Element} A scalable vector graphic (SVG) element representing the icon.
+ */
+
+const CheckCircleIcon: FC<CheckCircleIconProps> = ({
+	width = 24,
+	height = 24,
+	color = 'disabled',
+	...props
+}) => {
+	const isOutline = color === 'outline';
+	const isPrimaryOutline = color === 'primaryOutline';
+	const fillColor = isOutline || isPrimaryOutline ? 'none' : colorMap[color];
+	const strokeColor = isOutline
+		? colorMap['outline']
+		: isPrimaryOutline
+			? colorMap['primaryOutline']
+			: 'none';
+
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox='0 0 24 24'
+			fill='none'
+			xmlns='http://www.w3.org/2000/svg'
+			aria-label='Check Circle Icon'
+			role='img'
+			{...props}
+		>
+			<circle
+				cx='12'
+				cy='12'
+				r='11'
+				fill={fillColor}
+				stroke={strokeColor}
+				strokeWidth={isOutline || isPrimaryOutline ? 2 : 0}
+			/>
+
+			<path
+				d='M8 12L10.5 14.5L16 9'
+				stroke={
+					isOutline ? colorMap['outline'] : isPrimaryOutline ? colorMap['primaryOutline'] : 'white'
+				}
+				strokeWidth='2'
+				strokeLinecap='round'
+				strokeLinejoin='round'
+			/>
+		</svg>
+	);
+};
+
+export default CheckCircleIcon;

--- a/public/assets/icons/general/XCircleIcon.tsx
+++ b/public/assets/icons/general/XCircleIcon.tsx
@@ -1,0 +1,69 @@
+import React, { FC, SVGProps } from 'react';
+
+type IconColor = 'error' | 'success' | 'disabled' | 'outline';
+
+const colorMap: Record<IconColor, string> = {
+	error: '#F04438',
+	success: '#067647',
+	disabled: '#D0D5DD',
+	outline: '#344054',
+};
+
+interface XCircleIconProps extends SVGProps<SVGSVGElement> {
+	width?: number;
+	height?: number;
+	color?: IconColor;
+}
+
+/**
+ * A reusable SVG icon component for rendering an icon.
+ *
+ * @param {number} [width=24] - The width of the icon in pixels. Optional.
+ * @param {number} [height=24] - The height of the icon in pixels. Optional.
+ * @param {IconColor} [color='disabled'] - The stroke color of the icon. Accepts any valid CSS color value. Optional.
+ * @param {SVGProps<SVGSVGElement>} props - Additional SVG props such as `className`, `style`, or custom attributes.
+ *
+ * @returns {JSX.Element} A scalable vector graphic (SVG) element representing the icon.
+ */
+
+const XCircleIcon: FC<XCircleIconProps> = ({
+	width = 24,
+	height = 24,
+	color = 'disabled',
+	...props
+}) => {
+	const isOutline = color === 'outline';
+	const fillColor = isOutline ? 'none' : colorMap[color];
+	const strokeColor = isOutline ? colorMap['outline'] : colorMap[color];
+
+	return (
+		<svg
+			width={width}
+			height={height}
+			viewBox='0 0 24 24'
+			fill={fillColor}
+			xmlns='http://www.w3.org/2000/svg'
+			aria-label='X Circle Icon'
+			role='img'
+			{...props}
+		>
+			<circle
+				cx='12'
+				cy='12'
+				r='11'
+				fill={fillColor}
+				stroke={strokeColor}
+				strokeWidth={isOutline ? 2 : 0}
+			/>
+			<path
+				d='M15 9L9 15M9 9L15 15'
+				stroke={isOutline ? colorMap['outline'] : 'white'}
+				strokeWidth='2'
+				strokeLinecap='round'
+				strokeLinejoin='round'
+			/>
+		</svg>
+	);
+};
+
+export default XCircleIcon;

--- a/public/assets/icons/index.ts
+++ b/public/assets/icons/index.ts
@@ -2,3 +2,5 @@ export { default as SearchIcon } from './access/SearchIcon';
 
 export { default as EmptyStateIcon } from './general/EmptyStateIcon';
 export { default as SpinnerIcon } from './general/SpinnerIcon';
+export { default as CheckCircleIcon } from './general/CheckCircleIcon';
+export { default as XCircleIcon } from './general/XCircleIcon';

--- a/src/app/(client)/(auth)/components/ForgotPasswordForm.tsx
+++ b/src/app/(client)/(auth)/components/ForgotPasswordForm.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import React from 'react';
+
+import NextLink from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { Button, FormInput } from '@components';
+
+import { useForgotPasswordMutation } from '@/app/(client)/hooks/data';
+import { useForgotPasswordForm, useFormSubmission } from '@/app/(client)/hooks/forms';
+import { Form } from '@/shadcn-ui';
+
+export default function ForgotPasswordForm() {
+	const router = useRouter();
+	const forgotPasswordMutation = useForgotPasswordMutation();
+	const form = useForgotPasswordForm();
+
+	const {
+		getValues,
+		formState: { isValid },
+	} = form;
+
+	const { loading, handleSubmit, toast } = useFormSubmission({
+		mutation: forgotPasswordMutation,
+		getVariables: () => getValues(),
+		validate: () => isValid,
+		onSuccess: async (res) => {
+			// Dev-only: jump straight to reset with token
+			if (res?.token) {
+				router.replace(`/password/reset?token=${encodeURIComponent(res.token)}`);
+			} else {
+				// Fallback: a dev page that explains what's happening
+				router.replace('/password/reset?dev=1');
+			}
+		},
+		onError: (err) => {
+			const message = err.message ?? 'Could not process password reset request.';
+			toast.showToast({ message, variant: 'error' });
+		},
+		skipDefaultToast: true,
+	});
+
+	return (
+		<>
+			<div className='flex flex-col items-center gap-4'>
+				<h1 className='h1'>Forgot password?</h1>
+				<p className='body2'>Enter your account email to continue.</p>
+			</div>
+			<Form {...form}>
+				<form
+					onSubmit={handleSubmit}
+					className='min-w-[25em]'
+				>
+					<div className='mb-10 flex flex-col gap-5'>
+						<FormInput
+							control={form.control}
+							name='email'
+							label='Email'
+							type='email'
+							placeholder='m@example.com'
+						/>
+					</div>
+					<div>
+						<Button
+							type='submit'
+							fullWidth
+							disabled={!isValid}
+							loading={loading}
+							loadingText='Processing...'
+						>
+							Reset password
+						</Button>
+					</div>
+				</form>
+			</Form>
+			<NextLink href='/login'>← Back to login</NextLink>
+		</>
+	);
+}

--- a/src/app/(client)/(auth)/components/RegisterForm.tsx
+++ b/src/app/(client)/(auth)/components/RegisterForm.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 
 import { useQueryClient } from '@tanstack/react-query';
 
-import { Button, FormInput } from '@components';
+import { Button, FormInput, PasswordValidation } from '@components';
 
 import { useLoginMutation, useRegisterMutation } from '@/app/(client)/hooks/data';
 import { useFormSubmission, useRegisterForm } from '@/app/(client)/hooks/forms';
@@ -23,6 +23,8 @@ export default function RegisterForm() {
 	const {
 		getValues,
 		formState: { isValid },
+		watchPassword,
+		isPasswordTouched,
 	} = form;
 
 	const { loading, handleSubmit, toast } = useFormSubmission({
@@ -102,6 +104,13 @@ export default function RegisterForm() {
 							placeholder='Confirm your password'
 						/>
 					</div>
+
+					{/* Real-time password strength feedback */}
+					<PasswordValidation
+						passwordValue={watchPassword}
+						isBlur={isPasswordTouched}
+					/>
+
 					<div>
 						<Button
 							type='submit'

--- a/src/app/(client)/(auth)/components/ResetPasswordForm.tsx
+++ b/src/app/(client)/(auth)/components/ResetPasswordForm.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React, { useEffect } from 'react';
+
+import NextLink from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import { Button, FormInput, PasswordValidation } from '@components';
+
+import { useResetPasswordMutation } from '@/app/(client)/hooks/data';
+import { useFormSubmission, useResetPasswordForm } from '@/app/(client)/hooks/forms';
+import { queryKeys } from '@/lib/queryKeys';
+import { Form } from '@/shadcn-ui';
+
+export default function ResetPasswordForm() {
+	const router = useRouter();
+	const ResetPasswordMutation = useResetPasswordMutation();
+	const queryClient = useQueryClient();
+	const form = useResetPasswordForm();
+	const params = useSearchParams();
+	const token = params.get('token') ?? '';
+
+	const {
+		getValues,
+		formState: { isValid },
+		watchPassword,
+		isPasswordTouched,
+	} = form;
+
+	const { loading, handleSubmit, toast } = useFormSubmission({
+		onSubmit: async () => {
+			await ResetPasswordMutation.mutateAsync({
+				token,
+				newPassword: getValues('newPassword'),
+				confirmPassword: getValues('confirmPassword'),
+			});
+		},
+		onSuccess: async () => {
+			// Invalidate auth cache so useSessionUser refetches immediately.
+			await queryClient.invalidateQueries({ queryKey: queryKeys.auth.session });
+
+			const message = ResetPasswordMutation.data?.message ?? 'Your password has been reset.';
+			toast.showToast({ message, variant: 'success' });
+
+			router.replace('/login?reset=done');
+		},
+		onError: (err) => {
+			const message = err instanceof Error ? err.message : 'Could not reset password';
+			toast.showToast({ message, variant: 'error' });
+		},
+		skipDefaultToast: true,
+	});
+
+	/* ------------- early-guard: no token ------------- */
+	useEffect(() => {
+		if (!token) {
+			toast.showToast({
+				message: 'We couldn’t retrieve a reset token. Please try again.',
+				variant: 'error',
+			});
+			router.replace('/password/forgot');
+		}
+	}, [token, router, toast]);
+
+	return (
+		<>
+			<div className='flex flex-col items-center gap-4'>
+				<h1 className='h1'>Set new password</h1>
+				<p className='body2'>Your new password must be different from your previous password.</p>
+			</div>
+			<Form {...form}>
+				<form
+					onSubmit={handleSubmit}
+					className='min-w-[25em]'
+				>
+					<div className='mb-10 flex flex-col gap-5'>
+						<FormInput
+							control={form.control}
+							name='newPassword'
+							label='New password'
+							type='password'
+							placeholder='Create a password'
+						/>
+						<FormInput
+							control={form.control}
+							name='confirmPassword'
+							label='Confirm password'
+							type='password'
+							placeholder='Confirm your password'
+						/>
+					</div>
+
+					{/* Real-time password strength feedback */}
+					<PasswordValidation
+						passwordValue={watchPassword}
+						isBlur={isPasswordTouched}
+					/>
+
+					<div>
+						<Button
+							type='submit'
+							fullWidth
+							disabled={!isValid}
+							loading={loading}
+							loadingText='Resetting...'
+						>
+							Reset password
+						</Button>
+					</div>
+				</form>
+			</Form>
+			<NextLink href='/login'>← Back to login</NextLink>
+		</>
+	);
+}

--- a/src/app/(client)/(auth)/password/reset/page.tsx
+++ b/src/app/(client)/(auth)/password/reset/page.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
 import AuthFormWrapper from '../../components/AuthFormWrapper';
-import ForgotPasswordForm from '../../components/ForgotPasswordForm';
+import ResetPasswordForm from '../../components/ResetPasswordForm';
 
-export default function ForgotPasswordPage() {
+export default function ResetPasswordPage() {
 	return (
 		<AuthFormWrapper>
-			<ForgotPasswordForm />
+			<ResetPasswordForm />
 		</AuthFormWrapper>
 	);
 }

--- a/src/app/(client)/components/auth/GoogleAuthButton.tsx
+++ b/src/app/(client)/components/auth/GoogleAuthButton.tsx
@@ -138,7 +138,7 @@ function AuthDropdownContent({ user, onSignOut, isSigningOut }: AuthDropdownCont
 				className='text-destructive focus:text-destructive'
 			>
 				<LogOut className='mr-2' />
-				{isSigningOut ? 'Signing out…' : 'Sign out'}
+				{isSigningOut ? 'Logging out...' : 'Log out'}
 			</DropdownMenuItem>
 		</DropdownMenuContent>
 	);
@@ -194,7 +194,7 @@ function SignInState({
 						<GoogleIcon />
 					)}
 					<span className={isSigningIn ? 'opacity-60' : ''}>
-						{isSigningIn ? 'Signing in...' : 'Continue with Google'}
+						{isSigningIn ? 'Logging in...' : 'Continue with Google'}
 					</span>
 				</div>
 			</SidebarMenuButton>
@@ -208,7 +208,7 @@ function SignInState({
 			className={className}
 			aria-label='Continue with Google'
 			loading={isSigningIn}
-			loadingText='Signing in...'
+			loadingText='Logging in...'
 			startIcon={<GoogleIcon />}
 		>
 			{!isSigningIn && 'Continue with Google'}

--- a/src/app/(client)/components/form/PasswordValidation.tsx
+++ b/src/app/(client)/components/form/PasswordValidation.tsx
@@ -1,0 +1,58 @@
+// ──────────────────────────────────────────────────────────────────────────────
+// PasswordValidation.tsx
+// ----------------------------------------------------------------------------
+// Live “strength” feedback shown below a password field.
+// Relies on getPasswordChecks() so the regexes remain DRY.
+// ----------------------------------------------------------------------------
+import { CheckCircleIcon, XCircleIcon } from '@icons';
+
+import { getPasswordChecks } from '@/lib/validation';
+
+interface PasswordValidationProps {
+	/** Current password text from the parent form */
+	passwordValue: string;
+	/** Show red cross icons only after the field has lost focus */
+	isBlur?: boolean;
+}
+
+export default function PasswordValidation({
+	passwordValue,
+	isBlur = false,
+}: PasswordValidationProps) {
+	const { isLengthValid, hasUppercase, hasSymbol } = getPasswordChecks(passwordValue);
+
+	/**
+	 * Returns the appropriate icon for each rule.
+	 * – While the user is typing (not blurred yet), we show grey “disabled”
+	 *   circles to avoid scaring them.
+	 * – After blur, failing rules show a red X.
+	 */
+	const renderIcon = (rulePassed: boolean) =>
+		passwordValue && !rulePassed && isBlur ? (
+			<XCircleIcon color='error' />
+		) : (
+			<CheckCircleIcon color={rulePassed ? 'success' : 'disabled'} />
+		);
+
+	return (
+		<div className='mb-10 flex flex-col gap-3'>
+			{/* ≥ 8 chars ----------------------------------------------------------- */}
+			<div className='flex items-center gap-3'>
+				{renderIcon(isLengthValid)}
+				<p className='body2'>Must be at least 8 characters</p>
+			</div>
+
+			{/* uppercase ---------------------------------------------------------- */}
+			<div className='flex items-center gap-3'>
+				{renderIcon(hasUppercase)}
+				<p className='body2'>Must contain at least one uppercase letter</p>
+			</div>
+
+			{/* symbol ------------------------------------------------------------- */}
+			<div className='flex items-center gap-3'>
+				{renderIcon(hasSymbol)}
+				<p className='body2'>Must include at least one symbol</p>
+			</div>
+		</div>
+	);
+}

--- a/src/app/(client)/components/index.ts
+++ b/src/app/(client)/components/index.ts
@@ -1,6 +1,7 @@
 export { default as SearchBar } from './input/SearchBar';
 
 export { default as FormInput } from './form/FormInput';
+export { default as PasswordValidation } from './form/PasswordValidation';
 
 export { default as LoadingSpinner } from './loaders/LoadingSpinner';
 

--- a/src/app/(client)/hooks/data/auth/useForgotPasswordMutation.ts
+++ b/src/app/(client)/hooks/data/auth/useForgotPasswordMutation.ts
@@ -1,0 +1,20 @@
+/**
+ * useForgotPasswordMutation.ts
+ * ---------------------------------------------------------------------------
+ * Wraps POST /api/auth/password/forgot in a TanStack-Query mutation.
+ */
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { ForgotPasswordData, ForgotPasswordResult } from '@/lib/models';
+
+export default function useForgotPasswordMutation() {
+	return useMutation<ForgotPasswordResult, Error, ForgotPasswordData>({
+		mutationFn: async ({ email }) => {
+			const { data } = await axios.post<ForgotPasswordResult>('/api/auth/password/forgot', {
+				email,
+			});
+			return data;
+		},
+	});
+}

--- a/src/app/(client)/hooks/data/auth/useResetPasswordMutation.ts
+++ b/src/app/(client)/hooks/data/auth/useResetPasswordMutation.ts
@@ -1,0 +1,22 @@
+/**
+ * useResetPasswordMutation.ts
+ * ---------------------------------------------------------------------------
+ * Wraps POST /api/auth/password/reset in a TanStack-Query mutation.
+ */
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+
+import { ResetPasswordData, ResetPasswordResult } from '@/lib/models';
+
+export default function useResetPasswordMutation() {
+	return useMutation<ResetPasswordResult, Error, ResetPasswordData>({
+		mutationFn: async ({ token, newPassword, confirmPassword }) => {
+			const { data } = await axios.post<ResetPasswordResult>('/api/auth/password/reset', {
+				token,
+				newPassword,
+				confirmPassword,
+			});
+			return data;
+		},
+	});
+}

--- a/src/app/(client)/hooks/data/index.ts
+++ b/src/app/(client)/hooks/data/index.ts
@@ -5,6 +5,8 @@
 
 export { default as useLoginMutation } from './auth/useLoginMutation';
 export { default as useRegisterMutation } from './auth/useRegisterMutation';
+export { default as useForgotPasswordMutation } from './auth/useForgotPasswordMutation';
+export { default as useResetPasswordMutation } from './auth/useResetPasswordMutation';
 
 export { useSessionUser } from './useSessionUser';
 export { useGoogleSignInMutation } from './useGoogleSignInMutation';

--- a/src/app/(client)/hooks/forms/index.ts
+++ b/src/app/(client)/hooks/forms/index.ts
@@ -2,3 +2,5 @@ export * from './useFormWithSchema';
 export * from './useFormSubmission';
 export * from './useLoginForm';
 export * from './useRegisterForm';
+export * from './useForgotPasswordForm';
+export * from './useResetPasswordForm';

--- a/src/app/(client)/hooks/forms/useForgotPasswordForm.ts
+++ b/src/app/(client)/hooks/forms/useForgotPasswordForm.ts
@@ -1,0 +1,11 @@
+/**
+ * useForgotPasswordForm.ts
+ * ---------------------------------------------------------------------------
+ * Thin RHF+Zod wrapper for the “Forgot password” screen.
+ */
+import { useFormWithSchema } from '@/app/(client)/hooks/forms';
+import { ForgotPasswordSchema, forgotPasswordDefaults } from '@/lib/validation';
+
+export function useForgotPasswordForm(mode: 'onBlur' | 'onChange' | 'onSubmit' = 'onBlur') {
+	return useFormWithSchema(ForgotPasswordSchema, forgotPasswordDefaults, mode);
+}

--- a/src/app/(client)/hooks/forms/useFormSubmission.ts
+++ b/src/app/(client)/hooks/forms/useFormSubmission.ts
@@ -111,7 +111,7 @@ interface UseFormSubmissionProps<
 	/** Client-side validator – return `true` to proceed. */
 	validate?: () => boolean;
 	getVariables?: () => V;
-	onSuccess?: () => void;
+	onSuccess?: (result?: R) => void;
 	onError?: (error: E) => void;
 	/** Pre-canned toast messages on success/failure. */
 	successMessage?: string;
@@ -170,10 +170,12 @@ export const useFormSubmission = <V = void, R = unknown, E = unknown, C = unknow
 		if (validate && !validate()) return;
 
 		try {
+			let result: R | undefined;
+
 			if (mutation) {
 				/* ---------- adapter mode (tanstack-query) ---------- */
 				const variables = getVariables ? getVariables() : undefined;
-				await mutation.mutateAsync(variables as unknown as V);
+				result = await mutation.mutateAsync(variables as unknown as V);
 			} else if (onSubmit) {
 				/** @deprecated Legacy fallback mode */
 				setLocalLoading(true);
@@ -183,7 +185,7 @@ export const useFormSubmission = <V = void, R = unknown, E = unknown, C = unknow
 			if (successMessage && !skipDefaultToast) {
 				toast.showToast({ message: successMessage, variant: 'success' });
 			}
-			onSuccess?.();
+			onSuccess?.(result);
 		} catch (err: unknown) {
 			if (err instanceof ValidationAbortError) return;
 

--- a/src/app/(client)/hooks/forms/useResetPasswordForm.ts
+++ b/src/app/(client)/hooks/forms/useResetPasswordForm.ts
@@ -1,0 +1,20 @@
+/**
+ * useResetPasswordForm.ts
+ * ---------------------------------------------------------------------------
+ * RHF + Zod wrapper for the “Reset password” screen.
+ * Includes helpers for the live <PasswordValidation/> component.
+ */
+import { useWatch } from 'react-hook-form';
+
+import { useFormWithSchema } from '@/app/(client)/hooks/forms';
+import { ResetPasswordFormSchema, resetPasswordFormDefaults } from '@/lib/validation';
+
+export function useResetPasswordForm(mode: 'onBlur' | 'onChange' | 'onSubmit' = 'onBlur') {
+	const form = useFormWithSchema(ResetPasswordFormSchema, resetPasswordFormDefaults, mode);
+
+	/* helpers for PasswordValidation */
+	const watchPassword = useWatch({ control: form.control, name: 'newPassword' });
+	const isPasswordTouched = !!form.formState.touchedFields.newPassword;
+
+	return { ...form, watchPassword, isPasswordTouched };
+}

--- a/src/app/(server)/api/auth/password/forgot/route.ts
+++ b/src/app/(server)/api/auth/password/forgot/route.ts
@@ -5,7 +5,7 @@ import { AuthService, createErrorResponse, handleApiError } from '@services';
 import { ForgotPasswordSchema } from '@lib/validation/auth.schemas';
 
 /**
- * POST /api/auth/forgot
+ * POST /api/auth/password/forgot
  *
  * Initiates password reset process by generating a secure token
  * and associating it with the user's email address. For OAuth users

--- a/src/app/(server)/api/auth/password/reset/route.ts
+++ b/src/app/(server)/api/auth/password/reset/route.ts
@@ -5,7 +5,7 @@ import { AuthService, createErrorResponse, handleApiError } from '@services';
 import { ResetPasswordSchema } from '@lib/validation/auth.schemas';
 
 /**
- * POST /api/auth/reset
+ * POST /api/auth/password/reset
  *
  * Completes password reset flow using a valid token from the forgot password process.
  * Atomically updates the user's password and removes the reset token for security.

--- a/src/app/(server)/services/auth/service.ts
+++ b/src/app/(server)/services/auth/service.ts
@@ -127,6 +127,7 @@ export const AuthService = {
 	 * @param data - Password reset request following ResetPasswordData domain model
 	 * @throws ServiceError(400) when token is invalid or expired
 	 * @throws ServiceError(404) when user is not found
+	 * @throws ServiceError(422) when the new password matches the current password
 	 * @returns Promise<void>
 	 */
 	async resetPassword(data: ResetPasswordData): Promise<void> {
@@ -144,9 +145,17 @@ export const AuthService = {
 		// Find associated user
 		const user = await prisma.user.findUnique({
 			where: { email: rec.identifier },
-			select: { id: true },
+			select: { id: true, hashedPassword: true },
 		});
 		if (!user) throw new ServiceError('User missing', 404);
+
+		// Reject if new password equals current password
+		if (user.hashedPassword) {
+			const sameAsCurrent = await argon2.verify(user.hashedPassword, newPassword);
+			if (sameAsCurrent) {
+				throw new ServiceError('New password must be different from your current password.', 422);
+			}
+		}
 
 		// Hash new password and update atomically
 		const hashedPassword = await argon2.hash(newPassword);

--- a/src/lib/middleware/publicRoutes.ts
+++ b/src/lib/middleware/publicRoutes.ts
@@ -11,7 +11,7 @@ export const PUBLIC_ROUTES = [
 	'/', // landing page
 	'/login', // authentication pages
 	'/register',
-	'/forgot-password',
+	'/password/forgot',
 	'/403', // forbidden page
 ] as const;
 
@@ -20,7 +20,7 @@ export const PUBLIC_ROUTES = [
  * These will match the path and any nested routes.
  */
 export const PUBLIC_ROUTE_PREFIXES = [
-	'/reset-password', // password reset with tokens
+	'/password/reset', // password reset with tokens
 	'/api/auth', // NextAuth.js routes
 	'/invite', // team invitation pages (future)
 	'/_next', // Next.js asset pipeline

--- a/src/lib/validation/auth.schemas.ts
+++ b/src/lib/validation/auth.schemas.ts
@@ -85,6 +85,19 @@ export const ResetPasswordSchema = z
 	});
 
 /**
+ * Client-side schema for ResetPasswordForm (no token field).
+ */
+export const ResetPasswordFormSchema = z
+	.object({
+		newPassword: PasswordField,
+		confirmPassword: z.string(),
+	})
+	.refine((data) => data.newPassword === data.confirmPassword, {
+		error: 'Passwords do not match',
+		path: ['confirmPassword'],
+	});
+
+/**
  * Validation schema for password change requests by authenticated users.
  * Validates current password and new password requirements with confirmation.
  * Produces types compatible with ChangePasswordData domain model.
@@ -123,8 +136,7 @@ export const registerDefaults: RegisterData = {
 export const forgotPasswordDefaults: ForgotPasswordData = { email: '' };
 
 /** Default values for password reset form */
-export const resetPasswordDefaults: ResetPasswordData = {
-	token: '',
+export const resetPasswordFormDefaults: ResetPasswordFormData = {
 	newPassword: '',
 	confirmPassword: '',
 };
@@ -147,6 +159,9 @@ export type ForgotPasswordData = z.infer<typeof ForgotPasswordSchema>;
 
 /** Type inference for ResetPasswordSchema - matches ResetPasswordData domain model */
 export type ResetPasswordData = z.infer<typeof ResetPasswordSchema>;
+
+/** Type inference for ResetPasswordFormSchema - client-side form values (no token) */
+export type ResetPasswordFormData = z.infer<typeof ResetPasswordFormSchema>;
 
 /** Type inference for ChangePasswordSchema - matches ChangePasswordData domain model */
 export type ChangePasswordData = z.infer<typeof ChangePasswordSchema>;

--- a/src/lib/validation/validationUtils.ts
+++ b/src/lib/validation/validationUtils.ts
@@ -16,10 +16,22 @@ export const PASSWORD_RULES = {
  * @param password - The password to validate
  * @returns boolean - True if the password meets complexity rules, false otherwise
  */
-export function validatePasswordComplexity(password: string): boolean {
+export const validatePasswordComplexity = (password: string): boolean => {
 	return (
 		password.length >= PASSWORD_RULES.MIN_LEN &&
 		PASSWORD_RULES.NEEDS_UPPERCASE.test(password) &&
 		PASSWORD_RULES.NEEDS_SYMBOL.test(password)
 	);
-}
+};
+
+/**
+ * Checks a password string against the current password policy.
+ *
+ * @param password - The password string to check.
+ * @returns An object with booleans for each password rule.
+ */
+export const getPasswordChecks = (password: string) => ({
+	isLengthValid: password.length >= PASSWORD_RULES.MIN_LEN,
+	hasUppercase: PASSWORD_RULES.NEEDS_UPPERCASE.test(password),
+	hasSymbol: PASSWORD_RULES.NEEDS_SYMBOL.test(password),
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -26,7 +26,7 @@ export default auth((req) => {
 	}
 
 	// Redirect authenticated users away from auth pages to default dashboard
-	if (['/login', '/register', '/forgot-password'].includes(pathname)) {
+	if (['/login', '/register', '/password/forgot'].includes(pathname)) {
 		return NextResponse.redirect(new URL('/dashboard', req.url));
 	}
 


### PR DESCRIPTION
Closes #29
---

### ✨ Summary
This PR integrates the authentication flow (forgot/reset password, logout) end to end. It wires RHF + Zod forms to TanStack Query, introduces reusable hooks (forms, data) and a live `PasswordValidation` UI, implements accessible inline/server error handling, and sets up cache invalidation.

### ✅ Implemented

**🔐 Auth data layer**
- Added `useForgotPasswordMutation` and `useResetPasswordMutation` (TanStack Query) under hooks/data/auth.
- Updated `useSignOutMutation` to disable automatic redirect and manually navigate with `router.replace(callbackUrl ?? '/login')` for consistent post-logout UX.

**🧾 Forms (RHF + Zod)**

Implemented reusable form hooks in hooks/forms:

- `useForgotPasswordForm` and `useResetPasswordForm` — composed hooks used by the pages.

**🖥️ Pages**

Moved `forgot` and `reset` password from SSR `page.tsx` to client components (`ForgotPasswordForm.tsx`, `ResetPasswordForm.tsx`).

- **Forgot password** (`app/(client)/(auth)/password/forgot/page.tsx` + `ForgotPasswordForm.tsx`):
    - Wired to RHF + schemas + `useForgotPasswordMutation`.
- **Reset password** (`app/(client)/(auth)/password/reset/page.tsx` + `ResetPasswordForm.tsx`):
    - Wired to RHF + schemas + `useResetPasswordMutation`.
    - invalidated `['auth', 'session']`, and redirected to `/login`.
    - Read `token` from `searchParams`.

**🧩 Reusable components & 🎨 Icons**

- Implemented a reusable `PasswordValidation` component and Applied it to all pages with password fields on `Register` and `Reset` Password forms.
- Added `XCircleIcon` and `CheckCircleIcon` SVGs and converted them to React components for use inside `PasswordValidation`.

**🛠️ Backend & API**

- Updated the `/api/auth/password/reset` endpoint to reject cases where the new password matches the current password.

**🛣️ Public Routes & Middleware**

- Updated `publicRoutes.ts` and `Middleware.ts` to include `/password/forgot` and `/password/reset`.